### PR TITLE
Correct shortcuts for split-window -h and -v

### DIFF
--- a/tmux.json
+++ b/tmux.json
@@ -270,7 +270,7 @@
     ]
   },
   {
-    "desc": "Split pane vertically",
+    "desc": "Split pane horizontally",
     "cat": "Panes",
     "shell": [],
     "tmuxcmd": [],
@@ -279,7 +279,7 @@
     ]
   },
   {
-    "desc": "Split pane horizontally",
+    "desc": "Split pane vertically",
     "cat": "Panes",
     "shell": [],
     "tmuxcmd": [],


### PR DESCRIPTION
These appear to be the wrong way around. If you execute `:split-window -h` or ``:split-window -v` it doesn't match the description here.