### PR TITLE
Fix incorrect Tmux keybindings + formatting error in json

### DIFF
--- a/tmux.json
+++ b/tmux.json
@@ -137,7 +137,7 @@
     "tmuxcmd": [],
     "shortcut": []
   },
-   {
+  {
     "desc": "Session and Window Preview",
     "cat": "Sessions",
     "keywords": [
@@ -149,7 +149,7 @@
     "shortcut": [
       "<span class=\"prefix\"><kbd>Ctrl</kbd> + <kbd>b</kbd> </span> <kbd>w</kbd>"
     ]
-  },  
+  },
   {
     "desc": "Move to previous session",
     "cat": "Sessions",
@@ -310,7 +310,7 @@
     "shell": [],
     "tmuxcmd": [],
     "shortcut": [
-      "<span class=\"prefix\"><kbd>Ctrl</kbd> + <kbd>b</kbd> </span> <kbd>%</kbd>"
+      "<span class=\"prefix\"><kbd>Ctrl</kbd> + <kbd>b</kbd> </span> <kbd>\"</kbd>"
     ]
   },
   {
@@ -319,7 +319,7 @@
     "shell": [],
     "tmuxcmd": [],
     "shortcut": [
-      "<span class=\"prefix\"><kbd>Ctrl</kbd> + <kbd>b</kbd> </span> <kbd>\"</kbd>"
+      "<span class=\"prefix\"><kbd>Ctrl</kbd> + <kbd>b</kbd> </span> <kbd>%</kbd>"
     ]
   },
   {


### PR DESCRIPTION
**Description:**

Fixes incorrect Tmux keybindings and addresses a formatting error in the JSON file. The incorrect keybindings for splitting panes have been corrected based on the official Tmux documentation.

**Changes Made:**

- Updated the keybindings for splitting panes:
  - Horizontal split: `Ctrl + b` followed by `"`
  - Vertical split: `Ctrl + b` followed by `%`

**Formatting Fixes:**

- Corrected formatting errors, including tab inconsistencies.