### PR TITLE
Add display menu for common actions in current window or pane

### DIFF
--- a/tmux.json
+++ b/tmux.json
@@ -304,6 +304,15 @@
     ]
   },
   {
+    "desc": "Open Window actions menu",
+    "cat": "Windows",
+    "shell": [],
+    "tmuxcmd": [],
+    "shortcut": [
+      "<prefix/> <kbd>&lt;</kbd>"
+    ]
+  },
+  {
     "desc": "Reorder window, swap window number 2(src) and 1(dst)",
     "cat": "Windows",
     "shell": [],


### PR DESCRIPTION
**New shortcut added:**

* Added a shortcut (`<prefix/> <kbd>&lt;</kbd>`) to open the Window actions menu in the Windows category. (requires tmux 3.0+)